### PR TITLE
Added method signature scanning

### DIFF
--- a/dnpatch/Extensions.cs
+++ b/dnpatch/Extensions.cs
@@ -1,0 +1,48 @@
+﻿using dnlib.DotNet.Emit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnpatch
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Dynamic IndexOf
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="haystack"></param>
+        /// <param name="needle"></param>
+        /// <returns></returns>
+        public static IEnumerable<int> IndexOf<T>(this T[] haystack, T[] needle)
+        {
+            if ((needle != null) && (haystack.Length >= needle.Length))
+            {
+                for (int l = 0; l < haystack.Length - needle.Length + 1; l++)
+                {
+                    if (!needle.Where((data, index) => !haystack[l + index].Equals(data)).Any())
+                    {
+                        yield return l;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get OpCode[] from Instruction[]
+        /// </summary>
+        /// <param name="main"></param>
+        /// <returns></returns>
+        public static OpCode[] GetOpCodes(this Instruction[] main)
+        {
+            List<OpCode> opcodes = new List<OpCode>();
+            for (int i = 0; i < main.Length; i++)
+            {
+                opcodes.Add(main[i].OpCode);
+            }
+            return opcodes.ToArray();
+        }
+    }
+}

--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -653,6 +653,35 @@ namespace dnpatch
             return targets.ToArray();
         }
 
+        /// <summary>
+        /// Find methods that contain a certain OpCode[] signature
+        /// </summary>
+        /// <returns></returns>
+        public HashSet<MethodDef> FindMethodsByOpCodeSignature(OpCode[] signature)
+        {
+            HashSet<MethodDef> found = new HashSet<MethodDef>();
+
+            foreach (TypeDef td in _module.Types)
+            {
+                foreach (MethodDef md in td.Methods)
+                {
+                    if (md.HasBody)
+                    {
+                        if (md.Body.HasInstructions)
+                        {
+                            OpCode[] ops = md.Body.Instructions.ToArray().GetOpCodes();
+                            if (ops.IndexOf<OpCode>(signature).Count() > 0)
+                            {
+                                found.Add(md);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return found;
+        }
+
         public  Target[] FindInstructionsByOpcode(Target target, OpCode[] opcode, bool removeIfFound = false)
         {
             List<ObfuscatedTarget> obfuscatedTargets = new List<ObfuscatedTarget>();

--- a/dnpatch/dnpatch.csproj
+++ b/dnpatch/dnpatch.csproj
@@ -29,6 +29,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="dnlib, Version=1.6.0.0, Culture=neutral, PublicKeyToken=50e96378b6e77999, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -44,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="ObfuscatedTarget.cs" />
     <Compile Include="Patcher.cs" />
     <Compile Include="PatchHelper.cs" />


### PR DESCRIPTION
Hi, pushed an update to perform MethodDef signature scanning, please review this code and change it to your way of doing it (this is just one way, but it doesn't really conform to your coding standard)

```c#
OpCode[] signature = new[] {
    OpCodes.Ldstr,
    OpCodes.Call
};
var result = p.FindMethodsByOpCodeSignature(signature);
if(result.Count > 0)
{
    foreach(MethodDef method in result){
        Console.WriteLine(method.Name + " contains the signature!");
}