### PR TITLE
Explicit parameter checking instead of taking First & Last

### DIFF
--- a/dnpatch.script/Script.cs
+++ b/dnpatch.script/Script.cs
@@ -94,7 +94,7 @@ namespace dnpatch.script
                     JArray instructions = (JArray) t["instructions"];
                     if (instructions.Count == 1)
                     {
-                        if (instructions[0]["opcode"] != null && instructions[0]["operand" != "")
+                        if (instructions[0]["opcode"] != null && instructions[0]["operand"] != "")
                         {
                             var operand = instructions[0].Last.Last;
                             if (operand.Type == JTokenType.Integer)

--- a/dnpatch.script/Script.cs
+++ b/dnpatch.script/Script.cs
@@ -94,7 +94,7 @@ namespace dnpatch.script
                     JArray instructions = (JArray) t["instructions"];
                     if (instructions.Count == 1)
                     {
-                        if (instructions[0].First != null && instructions[0].First.ToString() != "")
+                        if (instructions[0]["opcode"] != null && instructions[0]["operand" != "")
                         {
                             var operand = instructions[0].Last.Last;
                             if (operand.Type == JTokenType.Integer)
@@ -114,7 +114,7 @@ namespace dnpatch.script
                                         operand.Value<string>());
                             }
                         }
-                        else
+                        else if(instructions[0]["opcode"] != null)
                         {
                             target.Instruction =
                                 Instruction.Create(


### PR DESCRIPTION
If opcode AND operand are not null we should go into the two-parameter constructor methods.
If opcode is not null but operand is, we go into single parameter constructor method.

If both are null, the app will probably crash. :D (But it already crashes on a whole lot of invalid functions anyway lol)

Could add additional string value checking but bleh.