### PR TITLE
Change the way instruction replacement works.

### DIFF
--- a/dnpatch.script/Script.cs
+++ b/dnpatch.script/Script.cs
@@ -128,7 +128,7 @@ namespace dnpatch.script
                         {
                             var instruction = instructions[i];
                             if (instruction["opcode"] != null && instruction["operand"] != null)
-                                target.Instruction =
+                                target.Instructions[i] =
                                     Instruction.Create((OpCode)GetInstructionField(instruction.First.First.ToString()).GetValue(this),
                                         instruction.Last.Last.Value<dynamic>());
                             else

--- a/dnpatch.script/Script.cs
+++ b/dnpatch.script/Script.cs
@@ -94,7 +94,7 @@ namespace dnpatch.script
                     JArray instructions = (JArray) t["instructions"];
                     if (instructions.Count == 1)
                     {
-                        if (instructions[0]["opcode"] != null && instructions[0]["operand"] != "")
+                        if (instructions[0]["opcode"] != null && instructions[0]["operand"] != null)
                         {
                             var operand = instructions[0].Last.Last;
                             if (operand.Type == JTokenType.Integer)
@@ -123,14 +123,16 @@ namespace dnpatch.script
                     }
                     else
                     {
-                        foreach (var instruction in instructions)
+                        target.Instructions = new Instruction[instructions.Count];
+                        for (int i = 0; i < instructions.Count; i++)
                         {
-                            if (instruction.First != null && instruction.First.Value<string>() != "")
-                                target.Instruction =
+                            var instruction = instructions[i];
+                            if (instruction["opcode"] != null && instruction["operand"] != null)
+                                target.Instructions[i] =
                                     Instruction.Create((OpCode)GetInstructionField(instruction.First.ToString()).GetValue(this),
                                         instruction.Last.Last.Value<dynamic>());
                             else
-                                target.Instruction =
+                                target.Instructions[i] =
                                     Instruction.Create(
                                         (OpCode)GetInstructionField(instruction.First.First.ToString()).GetValue(this));
                         }

--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -867,9 +867,9 @@ namespace dnpatch
             }
             else if (target.Indices != null && target.Instructions != null)
             {
-                foreach (var index in target.Indices)
-                {
-                    instructions[index] = target.Instructions[index];
+                for(int i = 0;i<target.Indices.Length;i++) {
+                    var index = target.Indices[i];
+                    instructions[index] = target.Instructions[i]
                 }
             }
             else

--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -869,7 +869,7 @@ namespace dnpatch
             {
                 for(int i = 0;i<target.Indices.Length;i++) {
                     var index = target.Indices[i];
-                    instructions[index] = target.Instructions[i]
+                    instructions[index] = target.Instructions[i];
                 }
             }
             else


### PR DESCRIPTION
Currently if you want to replace instructions at index 1, 5 and 8 you need to provide an array with instructions at index 1 5 and 8.

I think it is more logical to just put the instructions in an array at index 0, 1 and 2.

It also fixes support for script files with multiple instructions. (Previously the code for multiple instructions only actually loaded 1 instruction lol)