### PR TITLE
fixed array cast error

### DIFF
--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -915,7 +915,7 @@ namespace dnpatch
         {
             var type = FindType(target.Namespace + "." + target.Class, target.NestedClasses);
             MethodDef method = FindMethod(type, target.Method, target.Parameters, target.ReturnType);
-            return (Instruction[])method.Body.Instructions;
+            return method.Body.Instructions.ToArray();
         }
 
         public  void PatchOperand(Target target, string operand)


### PR DESCRIPTION
Got a cast error when casting from list to array. Fixed by using .ToArray instead.