### PR TITLE
if function BuildCall  want to find a have no parameter function is n…

### DIFF
--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -840,10 +840,18 @@ namespace dnpatch
             Importer importer = new Importer(Module);
             foreach (var m in type.GetMethods())
             {
-                if (m.Name == method && m.ReturnType == returnType && m.GetParameters().Length == parameters.Length && CheckParametersByType(m.GetParameters(), parameters))
+                if (m.Name == method && m.ReturnType == returnType)
                 {
-                    IMethod meth = importer.Import(m);
-                    return meth;
+                    if (m.GetParameters().Length == 0  && parameters == null)
+                    {
+                        IMethod meth = importer.Import(m);
+                        return meth;
+                    }
+                    if ( m.GetParameters().Length == parameters.Length && CheckParametersByType(m.GetParameters(), parameters))
+                    {
+                        IMethod meth = importer.Import(m);
+                        return meth;
+                    }
                 }
             }
             return null;


### PR DESCRIPTION
…ot find it.like ```Console.Readkey()```;

just like it:

Instruction.Create(OpCodes.Call,p.BuildCall(typeof(Console),"ReadKey",typeof(ConsoleKeyInfo),null)),

* Add examples
* If possible include screenshots from dnSpy