### PR TITLE
Add instruction inserting

### DIFF
--- a/dnpatch/PatchHelper.cs
+++ b/dnpatch/PatchHelper.cs
@@ -77,6 +77,32 @@ namespace dnpatch
             }
         }
 
+        public void PatchAndInsert(Target target)
+        {
+            string[] nestedClasses = { };
+            if (target.NestedClasses != null)
+            {
+                nestedClasses = target.NestedClasses;
+            }
+            else if (target.NestedClass != null)
+            {
+                nestedClasses = new[] { target.NestedClass };
+            }
+            var type = FindType(target.Namespace + "." + target.Class, nestedClasses);
+            var method = FindMethod(type, target.Method, target.Parameters, target.ReturnType);
+            var instructions = method.Body.Instructions;
+
+            if (target.Instructions != null && target.Indices != null)
+            {
+                for (int i = 0; i < target.Instructions.Length; i++)
+                {
+                    instructions.Insert(target.Indices[i], target.Instructions[i]);
+
+                }
+            }
+
+        }
+
         public  void PatchOffsets(Target target)
         {
             string[] nestedClasses = { };

--- a/dnpatch/Patcher.cs
+++ b/dnpatch/Patcher.cs
@@ -49,7 +49,11 @@ namespace dnpatch
             if ((target.Indices != null || target.Index != -1) &&
                 (target.Instruction != null || target.Instructions != null))
             {
-                _patcher.PatchOffsets(target);
+                if (target.InsertInstructions)
+                    _patcher.PatchAndInsert(target);
+
+                else
+                    _patcher.PatchOffsets(target);
             }
             else if ((target.Index == -1 && target.Indices == null) &&
                      (target.Instruction != null || target.Instructions != null))
@@ -69,7 +73,11 @@ namespace dnpatch
                 if ((target.Indices != null || target.Index != -1) &&
                     (target.Instruction != null || target.Instructions != null))
                 {
-                    _patcher.PatchOffsets(target);
+                    if (target.InsertInstructions)
+                        _patcher.PatchAndInsert(target);
+
+                    else
+                        _patcher.PatchOffsets(target);
                 }
                 else if ((target.Index == -1 && target.Indices == null) &&
                          (target.Instruction != null || target.Instructions != null))

--- a/dnpatch/Target.cs
+++ b/dnpatch/Target.cs
@@ -50,6 +50,11 @@ namespace dnpatch
 
     public partial class Target
     {
+        public bool InsertInstructions { get; set; } = false;
+    }
+
+    public partial class Target
+    {
         public string[] NestedClasses { get; set; }
     }
 


### PR DESCRIPTION
Added so targets can now be inserted while patching.


To insert instructions you have to follow a similar path of replacing them at a given index:
1. Add `Instruction(s)` to the `Target`;
2. Add the `Indices`/`Index ` to the `Target`
3. Set the bool var `InsertInstructions` to true (which defaults to false so it is compatible with codes from before this change)

``` CSharp
Instruction[] insertingOpCodes = {
                Instruction.Create(OpCodes.Ldstr, "Hello Sir"), // String to print
                Instruction.Create(OpCodes.Call, p.BuildCall(typeof(Console), "WriteLine", typeof(void), new[] { typeof(string) })), // Console.WriteLine call
                
            };
            Target insertingTarget = new Target()
            {
                Namespace = "Test",
                Class = "Program",
                Method = "Print",
                Instructions = insertingOpCodes,
                Indices = new[] { 3, 4 }, // Insert instructions at given index
                InsertInstructions = true // Tells the patcher to insert and not replace
            };

            p.Patch(insertingTarget);
            p.Save("Test15.exe");
```
Before the patch:
![image](https://user-images.githubusercontent.com/58634087/93601109-10798a00-f997-11ea-9354-c8e6b76f6ab8.png)
![image](https://user-images.githubusercontent.com/58634087/93601809-263b7f00-f998-11ea-97a5-6dc88c17aa8b.png)

After the patch:
![image](https://user-images.githubusercontent.com/58634087/93601555-c04ef780-f997-11ea-9790-94c1eea2c9d4.png)
![image](https://user-images.githubusercontent.com/58634087/93601614-d65cb800-f997-11ea-8af5-6ecde13df985.png)


